### PR TITLE
fix: Remove global svg style

### DIFF
--- a/src/scss/component-specific.scss
+++ b/src/scss/component-specific.scss
@@ -77,11 +77,6 @@ li[id^="alert-Information"] {
   border-left: $alert-border-left #19A5A3;
 }
 
-svg {
-  height: 0;
-  width: 0;
-}
-
 .alert-content-container .error-svg {
   color: #db0020;
   display: inline;


### PR DESCRIPTION
This was initially temporarily included with the svgs being injected at the top level.  That was then fixed so they wouldn't alter other svgs but this was left and causing unwanted side effects.